### PR TITLE
Add missing options for `lowhighType` enumeration

### DIFF
--- a/PW_CPV/qes_current_master.xsd
+++ b/PW_CPV/qes_current_master.xsd
@@ -200,7 +200,10 @@ datecode 220603
   <simpleType name="lowhighType">
   	<restriction base="string">
   	  <enumeration value="low"/>
+  	  <enumeration value="medium"/>
   	  <enumeration value="high"/>
+  	  <enumeration value="nowf"/>
+  	  <enumeration value="none"/>
   	</restriction>
   </simpleType>
   <!-- INPUT TYPE -->


### PR DESCRIPTION
The `disk_io` input supports (currently at least) 5 different values:

* `high`
* `medium`
* `low`
* `nowf`
* `none`

See documentation https://www.quantum-espresso.org/Doc/INPUT_PW.html#idm128 The input is represented in the XML schema by the `lowhighType` which only includes the `low` and `high` options though, causing parsing of calculations done with any of the other options to fail. Here the missing options are added.